### PR TITLE
immutable

### DIFF
--- a/contracts/claim/TierByConstructionClaim.sol
+++ b/contracts/claim/TierByConstructionClaim.sol
@@ -12,7 +12,7 @@ import { TierByConstruction } from "../tier/TierByConstruction.sol";
 contract TierByConstructionClaim is TierByConstruction {
     /// The minimum tier required for an address to claim anything at all.
     /// This tier must have been held continuously since before this contract was constructed.
-    ITier.Tier public minimumTier;
+    ITier.Tier public immutable minimumTier;
 
     /// Tracks every address that has already claimed to prevent duplicate claims.
     mapping(address => bool) public claims;

--- a/contracts/tier/ERC20BalanceTier.sol
+++ b/contracts/tier/ERC20BalanceTier.sol
@@ -21,7 +21,7 @@ import "./ReadOnlyTier.sol";
 /// - Assets that cannot be transferred, so are not eligible for `ERC20TransferTier`.
 /// - Lightweight, realtime checks that encumber the tiered address as little as possible.
 contract ERC20BalanceTier is ReadOnlyTier, ValueTier {
-    IERC20 public erc20;
+    IERC20 public immutable erc20;
 
     /// @param erc20_ The erc20 token contract to check the balance of at `report` time.
     /// @param tierValues_ 8 values corresponding to minimum erc20 balances for tiers ONE through EIGHT.

--- a/contracts/tier/ERC20TransferTier.sol
+++ b/contracts/tier/ERC20TransferTier.sol
@@ -26,7 +26,7 @@ import "./ReadWriteTier.sol";
 contract ERC20TransferTier is ReadWriteTier, ValueTier {
     using SafeERC20 for IERC20;
 
-    IERC20 public erc20;
+    IERC20 public immutable erc20;
 
     /// @param erc20_ The erc20 token contract to transfer balances from/to during `setTier`.
     /// @param tierValues_ 8 values corresponding to minimum erc20 balances for tiers ONE through EIGHT.

--- a/contracts/tier/TierByConstruction.sol
+++ b/contracts/tier/TierByConstruction.sol
@@ -9,8 +9,8 @@ import { ITier } from "./ITier.sol";
 /// The construction block is compared against the blocks returned by `report`.
 /// The `ITier` contract is paramaterised and set during construction.
 contract TierByConstruction {
-    ITier public tierContract;
-    uint256 public constructionBlock;
+    ITier public immutable tierContract;
+    uint256 public immutable constructionBlock;
 
     constructor(ITier tierContract_) public {
         tierContract = tierContract_;

--- a/contracts/tier/ValueTier.sol
+++ b/contracts/tier/ValueTier.sol
@@ -13,30 +13,52 @@ import { ITier } from "./ITier.sol";
 /// Note that `ValueTier` does NOT implement `ITier`.
 /// `ValueTier` does include state however, to track the `tierValues` so is not a library.
 contract ValueTier {
-    uint256[8] public tierValues;
+    uint256 private immutable tierOne;
+    uint256 private immutable tierTwo;
+    uint256 private immutable tierThree;
+    uint256 private immutable tierFour;
+    uint256 private immutable tierFive;
+    uint256 private immutable tierSix;
+    uint256 private immutable tierSeven;
+    uint256 private immutable tierEight;
 
     /// Set the `tierValues` on construction to be referenced immutably.
     constructor(uint256[8] memory tierValues_) public {
-        tierValues = tierValues_;
+        tierOne = tierValues_[0];
+        tierTwo = tierValues_[1];
+        tierThree = tierValues_[2];
+        tierFour = tierValues_[3];
+        tierFive = tierValues_[4];
+        tierSix = tierValues_[5];
+        tierSeven = tierValues_[6];
+        tierEight = tierValues_[7];
     }
 
     /// Complements the default solidity accessor for `tierValues`.
     /// Returns all the values in a list rather than requiring an index be specified.
-    /// @return The immutable `tierValues`.
-    function getTierValues() external view returns(uint256[8] memory) {
-        return tierValues;
+    /// @return tierValues_ The immutable `tierValues`.
+    function tierValues() public view returns(uint256[8] memory tierValues_) {
+        tierValues_[0] = tierOne;
+        tierValues_[1] = tierTwo;
+        tierValues_[2] = tierThree;
+        tierValues_[3] = tierFour;
+        tierValues_[4] = tierFive;
+        tierValues_[5] = tierSix;
+        tierValues_[6] = tierSeven;
+        tierValues_[7] = tierEight;
+        return tierValues_;
     }
 
     /// Converts a Tier to the minimum value it requires.
     /// Tier ZERO is always value 0 as it is the fallback.
     function tierToValue(ITier.Tier tier_) internal view returns(uint256) {
-        return tier_ > ITier.Tier.ZERO ? tierValues[uint256(tier_) - 1] : 0;
+        return tier_ > ITier.Tier.ZERO ? tierValues()[uint256(tier_) - 1] : 0;
     }
 
     /// Converts a value to the maximum Tier it qualifies for.
     function valueToTier(uint256 value_) internal view returns(ITier.Tier) {
         for (uint256 i = 0; i < 8; i++) {
-            if (value_ < tierValues[i]) {
+            if (value_ < tierValues()[i]) {
                 return ITier.Tier(i);
             }
         }

--- a/test/ValueTier.sol.ts
+++ b/test/ValueTier.sol.ts
@@ -41,41 +41,41 @@ describe("ValueTierTest", async function () {
 
   it('should set tierValues on construction', async () => {
     assert(
-      (await valueTier.tierValues(0)).eq(LEVELS[0]),
+      (await valueTier.tierValues())[0].eq(LEVELS[0]),
       "tier value at position 0 was not set"
     )
     assert(
-      (await valueTier.tierValues(1)).eq(LEVELS[1]),
+      (await valueTier.tierValues())[1].eq(LEVELS[1]),
       "tier value at position 1 was not set"
     )
     assert(
-      (await valueTier.tierValues(2)).eq(LEVELS[2]),
+      (await valueTier.tierValues())[2].eq(LEVELS[2]),
       "tier value at position 2 was not set"
     )
     assert(
-      (await valueTier.tierValues(3)).eq(LEVELS[3]),
+      (await valueTier.tierValues())[3].eq(LEVELS[3]),
       "tier value at position 3 was not set"
     )
     assert(
-      (await valueTier.tierValues(4)).eq(LEVELS[4]),
+      (await valueTier.tierValues())[4].eq(LEVELS[4]),
       "tier value at position 4 was not set"
     )
     assert(
-      (await valueTier.tierValues(5)).eq(LEVELS[5]),
+      (await valueTier.tierValues())[5].eq(LEVELS[5]),
       "tier value at position 5 was not set"
     )
     assert(
-      (await valueTier.tierValues(6)).eq(LEVELS[6]),
+      (await valueTier.tierValues())[6].eq(LEVELS[6]),
       "tier value at position 6 was not set"
     )
     assert(
-      (await valueTier.tierValues(7)).eq(LEVELS[7]),
+      (await valueTier.tierValues())[7].eq(LEVELS[7]),
       "tier value at position 7 was not set"
     )
   })
 
   it('should return all the values in a list rather than requiring an index be specified', async () => {
-    const tierValues = await valueTier.getTierValues()
+    const tierValues = await valueTier.tierValues()
 
     assert(
       tierValues.every((value:any, index:any) => value.eq(LEVELS[index])),

--- a/test/ValueTier.sol.ts
+++ b/test/ValueTier.sol.ts
@@ -39,40 +39,16 @@ describe("ValueTierTest", async function () {
     await valueTier.deployed()
   });
 
-  it('should set tierValues on construction', async () => {
-    assert(
-      (await valueTier.tierValues())[0].eq(LEVELS[0]),
-      "tier value at position 0 was not set"
-    )
-    assert(
-      (await valueTier.tierValues())[1].eq(LEVELS[1]),
-      "tier value at position 1 was not set"
-    )
-    assert(
-      (await valueTier.tierValues())[2].eq(LEVELS[2]),
-      "tier value at position 2 was not set"
-    )
-    assert(
-      (await valueTier.tierValues())[3].eq(LEVELS[3]),
-      "tier value at position 3 was not set"
-    )
-    assert(
-      (await valueTier.tierValues())[4].eq(LEVELS[4]),
-      "tier value at position 4 was not set"
-    )
-    assert(
-      (await valueTier.tierValues())[5].eq(LEVELS[5]),
-      "tier value at position 5 was not set"
-    )
-    assert(
-      (await valueTier.tierValues())[6].eq(LEVELS[6]),
-      "tier value at position 6 was not set"
-    )
-    assert(
-      (await valueTier.tierValues())[7].eq(LEVELS[7]),
-      "tier value at position 7 was not set"
-    )
-  })
+  it("should set tierValues on construction", async () => {
+    const tierValues = await valueTier.tierValues();
+
+    tierValues.forEach((tierValue, index) => {
+      assert(
+        tierValue.eq(LEVELS[index]),
+        `tier value at position ${index} was not set`
+      );
+    });
+  });
 
   it('should return all the values in a list rather than requiring an index be specified', async () => {
     const tierValues = await valueTier.tierValues()


### PR DESCRIPTION
before:

```
·--------------------------------------------|---------------------------|----------------|-----------------------------·
|            Solc version: 0.6.12            ·  Optimizer enabled: true  ·  Runs: 100000  ·  Block limit: 12450000 gas  │
·············································|···························|················|······························
|  Methods                                                                                                              │
································|············|·············|·············|················|···············|··············
|  Contract                     ·  Method    ·  Min        ·  Max        ·  Avg           ·  # calls      ·  eur (avg)  │
································|············|·············|·············|················|···············|··············
|  ERC20TransferTier            ·  setTier   ·      34022  ·      73460  ·         57855  ·            7  ·          -  │
································|············|·············|·············|················|···············|··············
|  ReadWriteTier                ·  setTier   ·      30487  ·      48280  ·         40090  ·           79  ·          -  │
································|············|·············|·············|················|···············|··············
|  ReserveTokenTest             ·  approve   ·      46135  ·      46147  ·         46144  ·            4  ·          -  │
································|············|·············|·············|················|···············|··············
|  ReserveTokenTest             ·  transfer  ·      31022  ·      53794  ·         34093  ·           50  ·          -  │
································|············|·············|·············|················|···············|··············
|  TierByConstructionClaim      ·  claim     ·      59826  ·      60426  ·         60066  ·            5  ·          -  │
································|············|·············|·············|················|···············|··············
|  TierByConstructionClaimTest  ·  claim     ·          -  ·          -  ·        106360  ·            1  ·          -  │
································|············|·············|·············|················|···············|··············
|  Deployments                               ·                                            ·  % of limit   ·             │
·············································|·············|·············|················|···············|··············
|  AlwaysTier                                ·          -  ·          -  ·        159775  ·        1.3 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ERC20BalanceTier                          ·          -  ·          -  ·        505801  ·        4.1 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ERC20TransferTier                         ·     963115  ·     963127  ·        963123  ·        7.7 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  NeverTier                                 ·          -  ·          -  ·        166477  ·        1.3 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ReadWriteTier                             ·          -  ·          -  ·        312261  ·        2.5 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ReserveTokenTest                          ·          -  ·          -  ·       1117964  ·          9 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierByConstructionClaim                   ·          -  ·          -  ·        470263  ·        3.8 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierByConstructionClaimTest               ·          -  ·          -  ·       1221906  ·        9.8 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierByConstructionTest                    ·          -  ·          -  ·        321651  ·        2.6 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierUtilTest                              ·          -  ·          -  ·        240908  ·        1.9 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ValueTierTest                             ·          -  ·          -  ·        367579  ·          3 %  ·          -  │
·--------------------------------------------|-------------|-------------|----------------|---------------|-------------·
```

after:

```
·--------------------------------------------|---------------------------|----------------|-----------------------------·
|            Solc version: 0.6.12            ·  Optimizer enabled: true  ·  Runs: 100000  ·  Block limit: 12450000 gas  │
·············································|···························|················|······························
|  Methods                                                                                                              │
································|············|·············|·············|················|···············|··············
|  Contract                     ·  Method    ·  Min        ·  Max        ·  Avg           ·  # calls      ·  eur (avg)  │
································|············|·············|·············|················|···············|··············
|  ERC20TransferTier            ·  setTier   ·      29150  ·      67737  ·         53410  ·            7  ·          -  │
································|············|·············|·············|················|···············|··············
|  ReadWriteTier                ·  setTier   ·      27630  ·      48280  ·         40040  ·           79  ·          -  │
································|············|·············|·············|················|···············|··············
|  ReserveTokenTest             ·  approve   ·      46135  ·      46147  ·         46144  ·            4  ·          -  │
································|············|·············|·············|················|···············|··············
|  ReserveTokenTest             ·  transfer  ·      31022  ·      53794  ·         34093  ·           50  ·          -  │
································|············|·············|·············|················|···············|··············
|  TierByConstructionClaim      ·  claim     ·      53386  ·      53986  ·         53626  ·            5  ·          -  │
································|············|·············|·············|················|···············|··············
|  TierByConstructionClaimTest  ·  claim     ·          -  ·          -  ·         99901  ·            1  ·          -  │
································|············|·············|·············|················|···············|··············
|  Deployments                               ·                                            ·  % of limit   ·             │
·············································|·············|·············|················|···············|··············
|  AlwaysTier                                ·          -  ·          -  ·        159775  ·        1.3 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ERC20BalanceTier                          ·          -  ·          -  ·        349148  ·        2.8 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ERC20TransferTier                         ·     818734  ·     818746  ·        818742  ·        6.6 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  NeverTier                                 ·          -  ·          -  ·        166477  ·        1.3 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ReadWriteTier                             ·          -  ·          -  ·        312261  ·        2.5 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ReserveTokenTest                          ·          -  ·          -  ·       1117964  ·          9 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierByConstructionClaim                   ·          -  ·          -  ·        437382  ·        3.5 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierByConstructionClaimTest               ·          -  ·          -  ·       1208439  ·        9.7 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierByConstructionTest                    ·          -  ·          -  ·        295420  ·        2.4 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  TierUtilTest                              ·          -  ·          -  ·        240908  ·        1.9 %  ·          -  │
·············································|·············|·············|················|···············|··············
|  ValueTierTest                             ·          -  ·          -  ·        233358  ·        1.9 %  ·          -  │
·--------------------------------------------|-------------|-------------|----------------|---------------|-------------·

```